### PR TITLE
Add support for Fedora-based distros

### DIFF
--- a/01-Setup.sh
+++ b/01-Setup.sh
@@ -63,6 +63,9 @@ fi
 # Check if user is on Debian-based system
 if [ -x "$(command -v apt)" ]; then
     sudo apt update && sudo apt install -y axel imagemagick xxd python3 python3-venv python3-pip nodejs npm bc rsync curl zip
+# Or if user is on Fedora-based system, do this instead
+elif [ -x "$(command -v dnf)" ]; then
+    sudo dnf install -y axel ImageMagick xxd python3 python3-devel python3-pip nodejs npm bc rsync curl zip
 # Or if user is on Arch-based system, do this instead
 elif [ -x "$(command -v pacman)" ]; then
     sudo pacman -Sy --needed archlinux-keyring && sudo pacman -S --needed axel imagemagick xxd python pyenv python-pip nodejs npm bc rsync curl zip
@@ -80,6 +83,8 @@ if ! command -v mkfs.exfat &> /dev/null; then
     echo "mkfs.exfat not found. Installing exfat driver..."
 if [ -x "$(command -v apt)" ]; then
     sudo apt install -y exfat-fuse
+elif [ -x "$(command -v dnf)" ]; then
+        sudo dnf install -y exfatprogs
 elif [ -x "$(command -v pacman)" ]; then
 	sudo pacman -S exfatprogs
 fi

--- a/01-Setup.sh
+++ b/01-Setup.sh
@@ -65,7 +65,7 @@ if [ -x "$(command -v apt)" ]; then
     sudo apt update && sudo apt install -y axel imagemagick xxd python3 python3-venv python3-pip nodejs npm bc rsync curl zip
 # Or if user is on Fedora-based system, do this instead
 elif [ -x "$(command -v dnf)" ]; then
-    sudo dnf install -y axel ImageMagick xxd python3 python3-devel python3-pip nodejs npm bc rsync curl zip
+    sudo dnf install -y gcc axel ImageMagick xxd python3 python3-devel python3-pip nodejs npm bc rsync curl zip
 # Or if user is on Arch-based system, do this instead
 elif [ -x "$(command -v pacman)" ]; then
     sudo pacman -Sy --needed archlinux-keyring && sudo pacman -S --needed axel imagemagick xxd python pyenv python-pip nodejs npm bc rsync curl zip


### PR DESCRIPTION
Added the option for `01-Setup.sh` to use `dnf` which is used by Fedora based distros. The implementation is based off how it already handles `apt` and `pacman`.
It works on a fresh Fedora install, and does not seem to have affected Debian/Arch based OSes with those being LinuxMint and EndevourOS in my testing.