### PR TITLE
support mount.exfat-fuse helper

### DIFF
--- a/03-Game-Installer.sh
+++ b/03-Game-Installer.sh
@@ -684,7 +684,7 @@ mkdir "${TOOLKIT_PATH}"/OPL 2>> "${LOG_FILE}"
 sudo mount ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
 
 # Handle possibility host system's `mount` is using Fuse
-if [ $? -ne 0 ] && [ hash mount.exfat-fuse ]; then
+if [ $? -ne 0 ] && hash mount.exfat-fuse; then
     sudo mount.exfat-fuse ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
 fi
 

--- a/03-Game-Installer.sh
+++ b/03-Game-Installer.sh
@@ -681,11 +681,11 @@ echo >> "${LOG_FILE}"
 echo "Mounting OPL partition" | tee -a "${LOG_FILE}"
 mkdir "${TOOLKIT_PATH}"/OPL 2>> "${LOG_FILE}"
 
-# Handle systems that require explicit mount.exfat-fuse
-if hash mount.exfat-fuse; then
+sudo mount ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
+
+# Handle possibility host system's `mount` is using Fuse
+if [ $? -ne 0 ] && [ hash mount.exfat-fuse ]; then
     sudo mount.exfat-fuse ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
-else
-    sudo mount ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
 fi
 
 if [ $? -ne 0 ]; then

--- a/03-Game-Installer.sh
+++ b/03-Game-Installer.sh
@@ -15,7 +15,7 @@ MISSING_ART=${TOOLKIT_PATH}/missing-art.log
 
 
 # Modify this path if your games are stored in a different location:
-GAMES_PATH="${TOOLKIT_PATH}/games"
+GAMES_PATH="/mnt/d/roms/ps2"
 
 POPS_FOLDER="${GAMES_PATH}/POPS"
 PS1_LIST="${TOOLKIT_PATH}/ps1.list"
@@ -680,7 +680,23 @@ echo >> "${LOG_FILE}"
 # Syncing PS2 games
 echo "Mounting OPL partition" | tee -a "${LOG_FILE}"
 mkdir "${TOOLKIT_PATH}"/OPL 2>> "${LOG_FILE}"
-sudo mount ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
+
+# Handle systems that require explicit mount.exfat-fuse
+if hash mount.exfat-fuse; then
+    sudo mount.exfat-fuse ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
+else
+	sudo mount ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
+fi
+
+if [ $? -ne 0 ]; then
+    echo
+    echo
+	echo "Error: Failed to mount ${DEVICE}3 - did you run 01-Setup.sh?"
+    read -n 1 -s -r -p "Press any key to exit..."
+    echo
+	exit 1;
+fi
+
 echo | tee -a "${LOG_FILE}"
 echo "Syncing PS2 games..." | tee -a "${LOG_FILE}"
 sudo rsync -r --progress --ignore-existing --delete --exclude=".*" "${GAMES_PATH}/CD/" "${TOOLKIT_PATH}/OPL/CD/" 2>>"${LOG_FILE}" | tee -a "${LOG_FILE}"

--- a/03-Game-Installer.sh
+++ b/03-Game-Installer.sh
@@ -685,16 +685,16 @@ mkdir "${TOOLKIT_PATH}"/OPL 2>> "${LOG_FILE}"
 if hash mount.exfat-fuse; then
     sudo mount.exfat-fuse ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
 else
-	sudo mount ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
+    sudo mount ${DEVICE}3 "${TOOLKIT_PATH}"/OPL
 fi
 
 if [ $? -ne 0 ]; then
     echo
     echo
-	echo "Error: Failed to mount ${DEVICE}3 - did you run 01-Setup.sh?"
+    echo "Error: Failed to mount ${DEVICE}3 - did you run 01-Setup.sh?"
     read -n 1 -s -r -p "Press any key to exit..."
     echo
-	exit 1;
+    exit 1;
 fi
 
 echo | tee -a "${LOG_FILE}"

--- a/03-Game-Installer.sh
+++ b/03-Game-Installer.sh
@@ -15,7 +15,7 @@ MISSING_ART=${TOOLKIT_PATH}/missing-art.log
 
 
 # Modify this path if your games are stored in a different location:
-GAMES_PATH="/mnt/d/roms/ps2"
+GAMES_PATH="${TOOLKIT_PATH}/games"
 
 POPS_FOLDER="${GAMES_PATH}/POPS"
 PS1_LIST="${TOOLKIT_PATH}/ps1.list"


### PR DESCRIPTION
On Ubuntu 24.04.2 LTS (under WSL), mounting an exfat partition requires the use of the helper `mount.exfat-fuse` instead of just `mount`. This small change is to handle the possibility that the script could be running on a system where `mount` isn't FUSE-aware.

Thank you for the wonderful project :)