### PR TITLE
bugfix: Avoid partial updates on Arch Linux

### DIFF
--- a/scripts/Setup.sh
+++ b/scripts/Setup.sh
@@ -73,13 +73,13 @@ elif [ -x "$(command -v dnf)" ]; then
     sudo dnf install -y gcc axel ImageMagick xxd python3 python3-devel python3-pip nodejs npm bc rsync curl unzip wget ffmpeg lvm2 fuse-libs dosfstools e2fsprogs glibc-common exfatprogs fuse-exfat util-linux parted 2>&1 | tee -a "${LOG_FILE}"
 # Or if user is on Arch-based system, do this instead
 elif [ -x "$(command -v pacman)" ]; then
-    sudo pacman -Sy --needed --noconfirm --quiet archlinux-keyring && sudo pacman -S --needed --noconfirm axel imagemagick xxd python pyenv python-pip nodejs npm bc rsync curl unzip wget ffmpeg lvm2 fuse2 dosfstools e2fsprogs glibc exfatprogs util-linux parted 2>&1 | tee -a "${LOG_FILE}"
+    sudo pacman -S --needed --noconfirm axel imagemagick xxd python pyenv python-pip nodejs npm bc rsync curl unzip wget ffmpeg lvm2 fuse2 dosfstools e2fsprogs glibc exfatprogs util-linux parted 2>&1 | tee -a "${LOG_FILE}"
 else
     error_msg "No supported package manager found (apt-get, dnf, pacman)."
 fi
 
 if [ $? -ne 0 ]; then
-    error_msg "Package installation failed." "See $LOG_FILE for details."
+    error_msg "Package installation failed. Please update your OS and try again." "See $LOG_FILE for details."
 else
     echo "[✓] Packages checked/installed." | tee -a "${LOG_FILE}"
 fi


### PR DESCRIPTION
On rolling release distributions like Arch, partial upgrades are highly discouraged as they can lead to system breakages.
This is explained in more detail on the ArchWiki in the system maintenance article: https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported

This is a valid approach on distributions like Ubuntu or Fedora, but not Arch. I believe this was done in good faith to help the user by first updating the repositories + keyring, and then installing PSBBN's dependencies using these new updated repos. By doing so, however, the system ends up in a broken state - newly installed packages update their needed libs and link against them, while the rest of the packages aren't touched at all and expect the old versions to be in place.
For example both Firefox and Chromium completely broke on my PC and kept crashing upon launch after running the PSBBN script :(

I can think of two solutions here - script either updates the OS completely before installing the new packages, or doesn't touch the local repositories (though this may lead to HTTP 404s).

First approach is problematic: complete OS upgrade may update the kernel, after which a reboot is mandatory, otherwise newly connected USB devices won't work. This is pretty unconvenient.
So I've settled for the second approach, which attempts to install the dependencies at versions the OS expects, and if that fails then we encourage the user to update the OS themselves. Not ideal but more reasonable in my opinion.

Finally thanks a lot for this project. I use it a lot with my PS2 😁 