### PR TITLE
Fix puppeteer check

### DIFF
--- a/PSBBN-Definitive-Patch.sh
+++ b/PSBBN-Definitive-Patch.sh
@@ -166,7 +166,7 @@ check_python_pkg() {
 
 check_node_pkg() {
     PACKAGE="$1"
-    NODE_MODULES_PATH="./scripts/node_modules"
+    NODE_MODULES_PATH="./node_modules"
 
     if NODE_PATH="$NODE_MODULES_PATH" node -e "require('$PACKAGE');" >/dev/null 2>&1; then
         echo "[✓] Node.js package '$PACKAGE' found" >> "$LOG_FILE"


### PR DESCRIPTION
I was using v2.11, the script has been updated to the latest 3.00 , but every time I start the `PSBBN-Definitive-Patch.sh` script, it fails to detect that I already have `puppeteer` and goes thru the whole setup process again.

Not sure about a clean install, but on my system, even after the upgrade to v3.00, the `node_modules` folder is on the root of the PSBBN folder, and not in `scripts/node_modules`.

So this PR updates NODE_MODULES_PATH to `./node_modules` to fix the setup loop.